### PR TITLE
Correct mirroring computation

### DIFF
--- a/ipython/SignalSmooth.ipynb
+++ b/ipython/SignalSmooth.ipynb
@@ -76,7 +76,7 @@
       "        raise ValueError, \"Window is on of 'flat', 'hanning', 'hamming', 'bartlett', 'blackman'\"\n",
       "    \n",
       "\n",
-      "    s=numpy.r_[x[window_len-1:0:-1],x,x[-1:-window_len:-1]]\n",
+      "    s=numpy.r_[x[window_len-1:0:-1],x,x[-2:-window_len-1:-1]]\n",
       "    #print(len(s))\n",
       "    if window == 'flat': #moving average\n",
       "        w=numpy.ones(window_len,'d')\n",


### PR DESCRIPTION
This will create a true mirror of the right end side instead of repeating the last element and then mirroring. This makes the mirroring consistent between left and right sides.