### PR TITLE
use self.size_method instead of the size function defined in example

### DIFF
--- a/ipython/Matplotlib_TreeMap.ipynb
+++ b/ipython/Matplotlib_TreeMap.ipynb
@@ -1,5 +1,7 @@
 {
- "metadata": {},
+ "metadata": {
+  "signature": "sha256:fae00d662ab0e2f99b845b3ff3ed7dc2a73e5fca5e2b310858b2eaf3cb9555f1"
+ },
  "nbformat": 3,
  "nbformat_minor": 0,
  "worksheets": [
@@ -21,9 +23,10 @@
      ]
     },
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
+     "cell_type": "heading",
+     "level": 4,
+     "metadata": {},
+     "source": [
       "\"\"\"\n",
       "Treemap builder using pylab.\n",
       "\n",
@@ -57,7 +60,7 @@
       "        width = upper[axis] - lower[axis]\n",
       "        try:\n",
       "            for child in self.iter_method(node):\n",
-      "                upper[axis] = lower[axis] + (width * float(size(child))) / size(node)\n",
+      "                upper[axis] = lower[axis] + (width * float(self.size_method(child))) / self.size_method(node)\n",
       "                self.addnode(child, list(lower), list(upper), axis + 1)\n",
       "                lower[axis] = upper[axis]\n",
       "\n",
@@ -92,10 +95,7 @@
       "\n",
       "    Treemap(tree, iter, size, random_color)\n",
       "    pylab.show()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
+     ]
     }
    ],
    "metadata": {}


### PR DESCRIPTION
The Treemap class of Matplotlib_Treemap.ipyn does not use the size_method given as parameter, but the function from the example