### PR TITLE
Move text from code to markdown cell

### DIFF
--- a/ipython/Reading_mat_files.ipynb
+++ b/ipython/Reading_mat_files.ipynb
@@ -10,19 +10,18 @@
      "metadata": {},
      "source": [
       "Reading mat files\n",
-      "================="
+      "=================",
+      "\n",
+      "Here are examples of how to read two variables `lat` and `lon` from a mat file called \"test.mat\".\n",
+      "\n",
+      "= Matlab up to 7.1 =\n",
+      "mat files created with Matlab up to version 7.1 can be read using the `mio` module part of `scipy.io`. Reading structures (and arrays of structures) is supported, elements are accessed with the same syntax as in Matlab: after reading a structure called e.g. `struct`, its `lat` element can be obtained with `struct.lat`, or `struct.__getattribute__('lat')` if the element name comes from a string.\n"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "Here are exemples of how to read two variables {{{lat}}} and {{{lon}}} from a mat file called \"test.mat\".\n",
-      "\n",
-      "= Matlab up to 7.1 =\n",
-      "mat files created with Matlab up to version 7.1 can be read using the {{{mio}}} module part of {{{scipy.io}}}. Reading structures (and arrays of structures) is supported, elements are accessed with the same syntax as in Matlab: after reading a structure called e.g. {{{struct}}}, its {{{lat}}} element can be obtained with {{{struct.lat}}}, or {{{struct.__getattribute__('lat')}}} if the element name comes from a string.\n",
-      "\n",
-      "{{{\n",
       "#!python\n",
       "#!/usr/bin/env python\n",
       "from scipy.io import loadmat\n",


### PR DESCRIPTION
Portion of the text was inside a code cell and it should be inside a markdown cell. I've moved it and replaced {{{ }}} with ``