### PR TITLE
Replaced broken URLs

### DIFF
--- a/ipython/KalmanFiltering.ipynb
+++ b/ipython/KalmanFiltering.ipynb
@@ -16,7 +16,7 @@
       "\n",
       "This is code implements the example given in pages 11-15 of [An\n",
       "Introduction to the Kalman\n",
-      "Filter](http://www.cs.unc.edu/~welch/kalman/kalmanIntro.html) by Greg\n",
+      "Filter](https://www.cs.unc.edu/~welch/media/pdf/kalman_intro.pdf) by Greg\n",
       "Welch and Gary Bishop, University of North Carolina at Chapel Hill,\n",
       "Department of Computer Science."
      ]
@@ -31,7 +31,7 @@
       "# Introduction to the Kalman Filter\" by Greg Welch and Gary Bishop,\n",
       "# University of North Carolina at Chapel Hill, Department of Computer\n",
       "# Science, TR 95-041,\n",
-      "# http://www.cs.unc.edu/~welch/kalman/kalmanIntro.html\n",
+      "# https://www.cs.unc.edu/~welch/media/pdf/kalman_intro.pdf\n",
       "\n",
       "# by Andrew D. Straw\n",
       "\n",


### PR DESCRIPTION
The page http://www.cs.unc.edu/~welch/kalman/kalman.html no longer exists but the pdf file is still there at https://www.cs.unc.edu/~welch/media/pdf/kalman_intro.pdf