### PR TITLE
MAINT: adjust resampling tutorial links

### DIFF
--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_1.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_1.ipynb
@@ -640,7 +640,7 @@
     "\n",
     "In addition, `monte_carlo_test` can be used to perform tests not yet implemented in SciPy, such as [the Lilliefors Test](https://www.tandfonline.com/doi/abs/10.1080/01621459.1967.10482916) for normality.\n",
     "\n",
-    "However, there are other types of statistical tests that do not test whether a sample is drawn from a particular distribution or family of distributions, but instead test whether  multiple samples are drawn from the same distribution. For these situations, we turn our attention to [Permutation Tests](https://nbviewer.org/github/mdhaber/scipy/blob/resampling_tutorial/doc/source/tutorial/stats/notebooks/resampling_tutorial_2.ipynb)."
+    "However, there are other types of statistical tests that do not test whether a sample is drawn from a particular distribution or family of distributions, but instead test whether  multiple samples are drawn from the same distribution. For these situations, we turn our attention to [Permutation Tests](https://nbviewer.org/github/scipy/scipy-cookbook/blob/main/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2.ipynb)."
    ]
   }
  ],

--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2.ipynb
@@ -358,7 +358,7 @@
    "id": "cb30657f-b7db-4762-95c2-1eebb2a05a64",
    "metadata": {},
    "source": [
-    "A wide variety of common hypothesis tests can be performed as permutation tests. We continue with several other examples to explore the flexibility of `permutation_test`, beginning with [Independent-Sample Tests](https://nbviewer.org/github/mdhaber/scipy/blob/resampling_tutorial/doc/source/tutorial/stats/notebooks/resampling_tutorial_2a.ipynb)."
+    "A wide variety of common hypothesis tests can be performed as permutation tests. We continue with several other examples to explore the flexibility of `permutation_test`, beginning with [Independent-Sample Tests](https://nbviewer.org/github/scipy/scipy-cookbook/blob/main/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2a.ipynb)."
    ]
   }
  ],

--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2a.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2a.ipynb
@@ -550,7 +550,7 @@
     "\n",
     "In addition, `permutation_test` with `permutation_type='independent'` can be used to perform tests not yet implemented in SciPy.\n",
     "\n",
-    "However, there are other types of permutation tests that do not assume that the samples are entirely independent. We continue the study of `permutation_test` with [Paired-Sample Tests](https://nbviewer.org/github/mdhaber/scipy/blob/resampling_tutorial/doc/source/tutorial/stats/notebooks/resampling_tutorial_2b.ipynb)."
+    "However, there are other types of permutation tests that do not assume that the samples are entirely independent. We continue the study of `permutation_test` with [Paired-Sample Tests](https://nbviewer.org/github/scipy/scipy-cookbook/blob/main/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2b.ipynb)."
    ]
   }
  ],

--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2b.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2b.ipynb
@@ -516,7 +516,7 @@
     "\n",
     "In addition, `permutation_test` with `permutation_type='samples'` can be used to perform tests not yet implemented in SciPy.\n",
     "\n",
-    "However, there are yet other types of permutation tests that assume neither that samples are independent nor paired. We conclude the study of `permutation_test` with [Correlated-Sample Tests](https://nbviewer.org/github/mdhaber/scipy/blob/resampling_tutorial/doc/source/tutorial/stats/notebooks/resampling_tutorial_2c.ipynb)."
+    "However, there are yet other types of permutation tests that assume neither that samples are independent nor paired. We conclude the study of `permutation_test` with [Correlated-Sample Tests](https://nbviewer.org/github/scipy/scipy-cookbook/blob/main/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2c.ipynb)."
    ]
   }
  ],

--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2c.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_2c.ipynb
@@ -504,7 +504,7 @@
     "\n",
     "In addition, `permutation_test` with `permutation_type='pairings'` can be used to perform tests not yet implemented in SciPy.\n",
     "\n",
-    "But there is much more to statistics than $p$-values! We conclude with a discussion of one of the most versatile techniques of all: [the bootstrap](https://nbviewer.org/github/mdhaber/scipy/blob/resampling_tutorial/doc/source/tutorial/stats/notebooks/resampling_tutorial_3.ipynb)."
+    "But there is much more to statistics than $p$-values! We conclude with a discussion of one of the most versatile techniques of all: [the bootstrap](https://nbviewer.org/github/scipy/scipy-cookbook/blob/main/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_3.ipynb)."
    ]
   }
  ],


### PR DESCRIPTION
Correct the cross-reference links now that these files are merged to scipy-cookbook.