### PR TITLE
DOC: stats: minor correction

### DIFF
--- a/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_1.ipynb
+++ b/ipython/ResamplingAndMonteCarloMethods/resampling_tutorial_1.ipynb
@@ -162,7 +162,7 @@
    "id": "4195c3fd-12fe-46b4-b681-83e0f57550ae",
    "metadata": {},
    "source": [
-    "Note that the originally observed value of the statistic, 6.98, is located in the right tail of the null distribution. Random samples from a normal distribution usually produce statistic values less than 6.98, and only occasionally produce higher values. Therefore, there is rather low probability of observing such an extreme value of the statistic under the null hypothesis that the sample is drawn from a normal population. This probability is quantified by the *inverse survival function* of the null distribution:"
+    "Note that the originally observed value of the statistic, 6.98, is located in the right tail of the null distribution. Random samples from a normal distribution usually produce statistic values less than 6.98, and only occasionally produce higher values. Therefore, there is rather low probability of observing such an extreme value of the statistic under the null hypothesis that the sample is drawn from a normal population. This probability is quantified by the *survival function* of the null distribution:"
    ]
   },
   {


### PR DESCRIPTION
"inverse survival function" should just be "survival function" here. See the example immediately below.