### PR TITLE
Update build script and docs config to handle newer versions

### DIFF
--- a/build.py
+++ b/build.py
@@ -247,7 +247,10 @@ def convert_file(dst_path, fn, editors, created, modified):
 
     root = tree.getroot()
     head = root.find('head')
-    container, = root.xpath("//div[@id='notebook-container']")
+    try:
+        container, = root.xpath("//div[@id='notebook-container']")
+    except ValueError:
+        container, = root.xpath("//body[@class='jp-Notebook']")
 
     headers = container.xpath('//h1')
     if headers:
@@ -344,18 +347,18 @@ def parse_wiki_legacy_tags():
         prev_line = None
 
         for line in f:
-            if re.match('^====+\s*$', line):
+            if re.match(r'^====+\s*$', line):
                 tags[0] = prev_line.strip()
                 tags[1] = None
                 tags[2] = None
                 continue
 
-            if re.match('^----+\s*$', line):
+            if re.match(r'^----+\s*$', line):
                 tags[1] = prev_line.strip()
                 tags[2] = None
                 continue
 
-            if re.match('^""""+\s*$', line):
+            if re.match(r'^""""+\s*$', line):
                 tags[2] = prev_line.strip()
                 continue
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,10 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     def setup(app):
-        app.add_stylesheet('scipy-cookbook.css')
+        try:
+            app.add_stylesheet('scipy-cookbook.css')
+        except AttributeError:
+            app.add_css_file('scipy-cookbook.css')
 else:
     html_context = {
         'css_files': [


### PR DESCRIPTION
Newer versions of Python, Jupyter-nbconvert and Sphinx can now work with the build system, using a few simple workarounds.
